### PR TITLE
explicit protobuf version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "eufy",
   "version": "0.0.1",
   "documentation": "https://www.home-assistant.io/integrations/eufy",
-  "requirements": ["lakeside==0.12","protobuf","pycryptodome","requests","setuptools"],
+  "requirements": ["protobuf==3.20","lakeside==0.12","pycryptodome","requests","setuptools"],
   "codeowners": [],
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
add explicit callout to last known good protobuf version to work with lakeside.  It's crusty and I hope to heck it doesn't have security vulns, but it works.