### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "eufy",
   "version": "0.0.1",
   "documentation": "https://www.home-assistant.io/integrations/eufy",
-  "requirements": ["protobuf==3.20","lakeside==0.12","pycryptodome","requests","setuptools"],
+  "requirements": ["protobuf","lakeside==0.13","pycryptodome","requests","setuptools"],
   "codeowners": [],
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
Removed protobuf version requirement
Upgraded lakeside from 0.12 to 0.13

Fixes dependency mismatch in HA Core v2023.5.x that causes integration to break.